### PR TITLE
Multi module spring boot support

### DIFF
--- a/.github/workflows/spring_boot_multi_module.yml
+++ b/.github/workflows/spring_boot_multi_module.yml
@@ -1,0 +1,36 @@
+name: Build/Test Spring Boot Multi-Module
+
+on:
+    workflow_dispatch:
+    push:
+        branches:
+            - main
+    pull_request:
+        branches:
+            - main
+
+jobs:
+    build:
+        strategy:
+            matrix:
+                include:
+                    - dockerfile: "Dockerfile"
+                      folder: "spring_boot_multi_module"
+                      image_name: "spring_boot_multi_module_image"
+                      service_port: 8050
+                      docker_port: 8080
+
+                    - dockerfile: "Dockerfile_EclipseTemurin"
+                      folder: "spring_boot_multi_module"
+                      image_name: "spring_boot_multi_module_eclipse_temurin_image"
+                      service_port: 8051
+                      docker_port: 8080
+
+        name: Build and Test Docker Images
+        uses: ./.github/workflows/buildAndTest.yml
+        with:
+            dockerfile: ${{ matrix.dockerfile }}
+            folder: ${{ matrix.folder }}
+            image_name: ${{ matrix.image_name }}
+            service_port: ${{ matrix.service_port }}
+            docker_port: ${{ matrix.docker_port }}

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Here are some stats for the current platforms:
 | [Vue.js](vuejs)                  | 185KB (Kilobytes!) |
 | [Node.js](nodejs)                | 62MB               |
 | [Spring Boot](spring_boot)       | 77MB               |
+| [Spring Boot Multi-Module](spring_boot_multi_module) | ~77MB              |
 | [Dotnet Core](dotnet_core)       | 53MB               |
 | [Python Flask](python_flask)     | 22.8MB             |
 

--- a/README.md
+++ b/README.md
@@ -7,17 +7,17 @@ Production-ready Dockerfiles for various platforms, designed for minimal image s
 The Dockerfiles in this repository are optimized to significantly reduce image sizes while maintaining functionality.
 Here are some stats for the current platforms:
 
-| Platform                         | Optimized Size     |
-| -------------------------------- | ------------------ |
-| [Static Website](static_website) | 81KB (Kilobytes!)  |
-| [Next.js](nextjs)                | 67MB               |
-| [React Vite](react_vite)         | 232KB (Kilobytes!) |
-| [Vue.js](vuejs)                  | 185KB (Kilobytes!) |
-| [Node.js](nodejs)                | 62MB               |
-| [Spring Boot](spring_boot)       | 77MB               |
+| Platform                                             | Optimized Size     |
+| ---------------------------------------------------- | ------------------ |
+| [Static Website](static_website)                     | 81KB (Kilobytes!)  |
+| [Next.js](nextjs)                                    | 67MB               |
+| [React / React Vite](react_vite)                     | 232KB (Kilobytes!) |
+| [Vue.js](vuejs)                                      | 185KB (Kilobytes!) |
+| [Node.js](nodejs)                                    | 62MB               |
+| [Spring Boot](spring_boot)                           | 77MB               |
 | [Spring Boot Multi-Module](spring_boot_multi_module) | ~77MB              |
-| [Dotnet Core](dotnet_core)       | 53MB               |
-| [Python Flask](python_flask)     | 22.8MB             |
+| [Dotnet Core](dotnet_core)                           | 53MB               |
+| [Python Flask](python_flask)                         | 22.8MB             |
 
 ## How to Use
 

--- a/nextjs/package-lock.json
+++ b/nextjs/package-lock.json
@@ -1597,6 +1597,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.1.1",
@@ -1766,6 +1767,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.0.0-rc-66855b96-20241106.tgz",
       "integrity": "sha512-klH7xkT71SxRCx4hb1hly5FJB21Hz0ACyxbXYAECEqssUjtJeFUAaI2U1DgJAzkGEnvEm3DkxuBchMC/9K4ipg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1775,6 +1777,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0-rc-66855b96-20241106.tgz",
       "integrity": "sha512-D25vdaytZ1wFIRiwNU98NPQ/upS2P8Co4/oNoa02PzHbh8deWdepjm5qwZM/46OdSiGv4WSWwxP55RO9obqJEQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "0.25.0-rc-66855b96-20241106"
       },

--- a/react_vite/package-lock.json
+++ b/react_vite/package-lock.json
@@ -71,6 +71,7 @@
       "integrity": "sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.0",
@@ -1365,6 +1366,7 @@
       "integrity": "sha512-NzahNKvjNhVjuPBQ+2G7WlxstQ+47kXZNHlUvFakDViuIEfGY926GqhMueQFZ7woG+sPiQKlF36XfrIUVSUfFg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -1416,6 +1418,7 @@
       "integrity": "sha512-hgUZ3kTEpVzKaK3uNibExUYm6SKKOmTU2BOxBSvOYwtJEPdVQ70kZJpPjstlnhCHcuc2WGfSbpKlb/69ttyN5Q==",
       "dev": true,
       "license": "MITClause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.18.0",
         "@typescript-eslint/types": "8.18.0",
@@ -1625,6 +1628,7 @@
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1733,6 +1737,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001669",
         "electron-to-chromium": "^1.5.41",
@@ -1951,6 +1956,7 @@
       "integrity": "sha512-whp8mSQI4C8VXd+fLgSM0lh3UlmcFtVwUQjyKCFfsp+2ItAIYhlq/hqGahGqHE6cv9unM41VlqKk2VtKYR2TaA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2782,6 +2788,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -3023,6 +3030,7 @@
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3101,6 +3109,7 @@
       "integrity": "sha512-Cmuo5P0ENTN6HxLSo6IHsjCLn/81Vgrp81oaiFFMRa8gGDj5xEjIcEpf2ZymZtZR8oU0P2JX5WuUp/rlXcHkAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.24.0",
         "postcss": "^8.4.49",

--- a/spring_boot/Dockerfile
+++ b/spring_boot/Dockerfile
@@ -22,14 +22,15 @@ RUN apk add --no-cache binutils && \
         --verbose \
         --add-modules $(cat modules.txt) \
         --strip-debug \
+        --strip-java-debug-attributes \
         --no-man-pages \
         --no-header-files \
-        --compress=2 \
+        --compress=zip-9 \
         --output /javaruntime && \
     rm -rf BOOT-INF META-INF app.jar modules.txt
 
 # Create a final image
-FROM alpine:3.20
+FROM alpine:3.21
 ENV JAVA_HOME=/opt/jdk/jdk-21
 ENV PATH="${JAVA_HOME}/bin:${PATH}"
 ARG APP_USER=spring

--- a/spring_boot_multi_module/.dockerignore
+++ b/spring_boot_multi_module/.dockerignore
@@ -1,0 +1,14 @@
+# .dockerignore file
+.DS_Store
+.next
+node_modules
+.mvn
+.git
+.gitignore
+README.md
+.dockerignore
+LICENSE
+.docker
+.gitlab
+**/target
+*.log

--- a/spring_boot_multi_module/.gitattributes
+++ b/spring_boot_multi_module/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/spring_boot_multi_module/.gitignore
+++ b/spring_boot_multi_module/.gitignore
@@ -1,0 +1,33 @@
+HELP.md
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/

--- a/spring_boot_multi_module/.mvn/wrapper/maven-wrapper.properties
+++ b/spring_boot_multi_module/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+wrapperVersion=3.3.2
+distributionType=only-script
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip

--- a/spring_boot_multi_module/Dockerfile
+++ b/spring_boot_multi_module/Dockerfile
@@ -26,14 +26,15 @@ RUN apk add --no-cache binutils && \
         --verbose \
         --add-modules $(cat modules.txt) \
         --strip-debug \
+        --strip-java-debug-attributes \
         --no-man-pages \
         --no-header-files \
-        --compress=2 \
+        --compress=zip-9 \
         --output /javaruntime && \
     rm -rf BOOT-INF META-INF app.jar modules.txt
 
 # Create a final image
-FROM alpine:3.20
+FROM alpine:3.21
 ENV JAVA_HOME=/opt/jdk/jdk-21
 ENV PATH="${JAVA_HOME}/bin:${PATH}"
 ARG APP_USER=spring

--- a/spring_boot_multi_module/Dockerfile
+++ b/spring_boot_multi_module/Dockerfile
@@ -1,0 +1,51 @@
+# https://medium.com/@RoussiAbdelghani/optimizing-java-base-docker-images-size-from-674mb-to-58mb-c1b7c911f622
+FROM maven:3.9.9-eclipse-temurin-21 AS build
+WORKDIR /app
+COPY . .
+RUN mvn clean package -DskipTests
+# Find the Spring Boot executable JAR (contains BOOT-INF)
+RUN find . -path "*/target/*.jar" \
+    -exec sh -c 'jar tf "$1" 2>/dev/null | grep -q "^BOOT-INF/" && echo "$1"' _ {} \; \
+    | head -1 \
+    | xargs -I{} cp {} /app/app.jar
+
+FROM eclipse-temurin:21-jdk-alpine AS jre-builder
+WORKDIR /app
+COPY --from=build /app/app.jar app.jar
+RUN apk add --no-cache binutils && \
+    # Determine the modules required by the application
+    jar -xf app.jar && \
+    jdeps --ignore-missing-deps -q  \
+        --recursive  \
+        --multi-release 21  \
+        --print-module-deps  \
+        --class-path 'BOOT-INF/lib/*'  \
+        app.jar > modules.txt && \
+    # Create a custom JRE
+    "$JAVA_HOME/bin/jlink" \
+        --verbose \
+        --add-modules $(cat modules.txt) \
+        --strip-debug \
+        --no-man-pages \
+        --no-header-files \
+        --compress=2 \
+        --output /javaruntime && \
+    rm -rf BOOT-INF META-INF app.jar modules.txt
+
+# Create a final image
+FROM alpine:3.20
+ENV JAVA_HOME=/opt/jdk/jdk-21
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+ARG APP_USER=spring
+COPY --from=jre-builder /javaruntime $JAVA_HOME
+RUN addgroup --system --gid 1001 "$APP_USER" && \
+    adduser --system --uid 1001 --home /app --ingroup "$APP_USER" "$APP_USER" && \
+    chown -R "$APP_USER":"$APP_USER" /app
+WORKDIR /app
+COPY --from=build --chown=$APP_USER:$APP_USER /app/app.jar app.jar
+USER $APP_USER
+EXPOSE 8080
+ENV server.port=8080
+# Uncomment the line below to set the active profile
+# ENV spring.profiles.active=prod
+CMD ["java", "-jar", "app.jar"]

--- a/spring_boot_multi_module/Dockerfile_EclipseTemurin
+++ b/spring_boot_multi_module/Dockerfile_EclipseTemurin
@@ -1,0 +1,25 @@
+# https://medium.com/@RoussiAbdelghani/optimizing-java-base-docker-images-size-from-674mb-to-58mb-c1b7c911f622
+FROM maven:3.9.9-eclipse-temurin-21 AS build
+WORKDIR /app
+COPY . .
+RUN mvn clean package -DskipTests
+# Find the Spring Boot executable JAR (contains BOOT-INF)
+RUN find . -path "*/target/*.jar" \
+    -exec sh -c 'jar tf "$1" 2>/dev/null | grep -q "^BOOT-INF/" && echo "$1"' _ {} \; \
+    | head -1 \
+    | xargs -I{} cp {} /app/app.jar
+
+FROM eclipse-temurin:21-jre-alpine
+ARG APP_USER=spring
+RUN addgroup --system --gid 1001 "$APP_USER" && \
+    adduser --system --uid 1001 "$APP_USER" && \
+    mkdir -p /app && \
+    chown -R "$APP_USER":"$APP_USER" /app
+WORKDIR /app
+COPY --from=build --chown=$APP_USER:$APP_USER /app/app.jar app.jar
+USER $APP_USER
+EXPOSE 8080
+ENV server.port=8080
+# Uncomment the line below to set the active profile
+# ENV spring.profiles.active=prod
+CMD ["java", "-jar", "app.jar"]

--- a/spring_boot_multi_module/README.md
+++ b/spring_boot_multi_module/README.md
@@ -1,0 +1,104 @@
+# Spring Boot Multi-Module with Docker
+
+This directory provides Dockerfiles for containerizing a multi-module Spring Boot application. It demonstrates how to
+structure and build a project with a shared library module (`common`) and a web application module (`web`).
+
+## Project Structure
+
+```
+spring_boot_multi_module/
+├── pom.xml              # Parent POM (aggregator)
+├── common/              # Shared library module
+│   ├── pom.xml
+│   └── src/main/java/com/davidr/common/
+│       ├── model/Greeting.java
+│       └── service/GreetingService.java
+└── web/                 # Spring Boot web application
+    ├── pom.xml
+    └── src/main/java/com/davidr/web/
+        ├── Application.java
+        └── HelloController.java
+```
+
+-   **common** — A plain JAR library providing shared models and services. Does not include the Spring Boot Maven plugin.
+-   **web** — The Spring Boot application that depends on `common`. Produces the executable fat JAR.
+
+## Files Included
+
+#### 1. [Dockerfile](./Dockerfile)
+
+-   Builds a lightweight Docker image for your multi-module Spring Boot application.
+-   Utilizes `jdeps` to analyze dependencies and include only the required modules in the JRE.
+
+#### 2. [Dockerfile_EclipseTemurin](./Dockerfile_EclipseTemurin)
+
+-   Uses the `eclipse-temurin` base image to build and run your Spring Boot application.
+-   Ideal for environments requiring the Eclipse Temurin JDK.
+
+## Key Differences from Single-Module Builds
+
+1.  **POM copying** — Each module's `pom.xml` is copied separately to leverage Docker layer caching.
+2.  **Build command** — Uses `mvn clean package -DskipTests -pl web -am` to build the web module and its dependencies.
+3.  **JAR path** — The executable JAR is at `web/target/*.jar`, not `target/*.jar`.
+
+## Setup Instructions
+
+### 1. Add a [.dockerignore](./.dockerignore) File
+
+Copy the [`.dockerignore`](.dockerignore) file in the root of your project.
+
+### 2. Dockerfile
+
+Create a [Dockerfile](Dockerfile) in the root of your project. This file contains the necessary commands to build the
+Docker image.
+
+### 3. Building the Docker Image
+
+#### Using the Regular Dockerfile
+
+```bash
+docker build -t spring-boot-multi-module-app .
+```
+
+#### Using Dockerfile_EclipseTemurin
+
+```bash
+docker build -f Dockerfile_EclipseTemurin -t spring-boot-multi-module-app:temurin .
+```
+
+### 4. Using Docker Slim (Optional)
+
+We can use Docker Slim to reduce the size further.
+
+**Note**: docker slim can remove some files that are required for your application to run. So, it is recommended to test
+the application after using Docker Slim.
+
+```bash
+docker run --rm -it -v /var/run/docker.sock:/var/run/docker.sock dslim/slim build --target spring-boot-multi-module-app
+```
+
+## Running the Docker Container
+
+After building the image, run the container with:
+
+```bash
+docker run -p 8080:8080 spring-boot-multi-module-app
+```
+
+Replace `spring-boot-multi-module-app` with the appropriate tag if using the `EclipseTemurin` version.
+
+### Endpoints
+
+-   `GET /` — Returns "Hello, World!"
+-   `GET /greet?name=David` — Returns a JSON greeting from the shared `common` module
+
+## Contributing
+
+If you have additional configurations or optimizations for Spring Boot Dockerfiles, feel free to submit a pull request.
+
+---
+
+## References
+
+-   https://snyk.io/blog/jlink-create-docker-images-spring-boot-java/
+-   https://medium.com/@RoussiAbdelghani/optimizing-java-base-docker-images-size-from-674mb-to-58mb-c1b7c911f622

--- a/spring_boot_multi_module/common/pom.xml
+++ b/spring_boot_multi_module/common/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>com.davidr</groupId>
+		<artifactId>spring_boot_multi_module</artifactId>
+		<version>0.0.1-SNAPSHOT</version>
+	</parent>
+	<artifactId>common</artifactId>
+	<name>common</name>
+	<description>Shared library module</description>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-context</artifactId>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/spring_boot_multi_module/common/src/main/java/com/davidr/common/model/Greeting.java
+++ b/spring_boot_multi_module/common/src/main/java/com/davidr/common/model/Greeting.java
@@ -1,0 +1,31 @@
+package com.davidr.common.model;
+
+public class Greeting {
+
+    private String message;
+    private String timestamp;
+
+    public Greeting() {
+    }
+
+    public Greeting(String message, String timestamp) {
+        this.message = message;
+        this.timestamp = timestamp;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public String getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(String timestamp) {
+        this.timestamp = timestamp;
+    }
+}

--- a/spring_boot_multi_module/common/src/main/java/com/davidr/common/service/GreetingService.java
+++ b/spring_boot_multi_module/common/src/main/java/com/davidr/common/service/GreetingService.java
@@ -1,0 +1,17 @@
+package com.davidr.common.service;
+
+import com.davidr.common.model.Greeting;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Service
+public class GreetingService {
+
+    public Greeting getGreeting(String name) {
+        String message = String.format("Hello, %s!", name);
+        String timestamp = LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+        return new Greeting(message, timestamp);
+    }
+}

--- a/spring_boot_multi_module/mvnw
+++ b/spring_boot_multi_module/mvnw
@@ -1,0 +1,259 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Apache Maven Wrapper startup batch script, version 3.3.2
+#
+# Optional ENV vars
+# -----------------
+#   JAVA_HOME - location of a JDK home dir, required when download maven via java source
+#   MVNW_REPOURL - repo url base for downloading maven distribution
+#   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+#   MVNW_VERBOSE - true: enable verbose log; debug: trace the mvnw script; others: silence the output
+# ----------------------------------------------------------------------------
+
+set -euf
+[ "${MVNW_VERBOSE-}" != debug ] || set -x
+
+# OS specific support.
+native_path() { printf %s\\n "$1"; }
+case "$(uname)" in
+CYGWIN* | MINGW*)
+  [ -z "${JAVA_HOME-}" ] || JAVA_HOME="$(cygpath --unix "$JAVA_HOME")"
+  native_path() { cygpath --path --windows "$1"; }
+  ;;
+esac
+
+# set JAVACMD and JAVACCMD
+set_java_home() {
+  # For Cygwin and MinGW, ensure paths are in Unix format before anything is touched
+  if [ -n "${JAVA_HOME-}" ]; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ]; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+      JAVACCMD="$JAVA_HOME/jre/sh/javac"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+      JAVACCMD="$JAVA_HOME/bin/javac"
+
+      if [ ! -x "$JAVACMD" ] || [ ! -x "$JAVACCMD" ]; then
+        echo "The JAVA_HOME environment variable is not defined correctly, so mvnw cannot run." >&2
+        echo "JAVA_HOME is set to \"$JAVA_HOME\", but \"\$JAVA_HOME/bin/java\" or \"\$JAVA_HOME/bin/javac\" does not exist." >&2
+        return 1
+      fi
+    fi
+  else
+    JAVACMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v java
+    )" || :
+    JAVACCMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v javac
+    )" || :
+
+    if [ ! -x "${JAVACMD-}" ] || [ ! -x "${JAVACCMD-}" ]; then
+      echo "The java/javac command does not exist in PATH nor is JAVA_HOME set, so mvnw cannot run." >&2
+      return 1
+    fi
+  fi
+}
+
+# hash string like Java String::hashCode
+hash_string() {
+  str="${1:-}" h=0
+  while [ -n "$str" ]; do
+    char="${str%"${str#?}"}"
+    h=$(((h * 31 + $(LC_CTYPE=C printf %d "'$char")) % 4294967296))
+    str="${str#?}"
+  done
+  printf %x\\n $h
+}
+
+verbose() { :; }
+[ "${MVNW_VERBOSE-}" != true ] || verbose() { printf %s\\n "${1-}"; }
+
+die() {
+  printf %s\\n "$1" >&2
+  exit 1
+}
+
+trim() {
+  # MWRAPPER-139:
+  #   Trims trailing and leading whitespace, carriage returns, tabs, and linefeeds.
+  #   Needed for removing poorly interpreted newline sequences when running in more
+  #   exotic environments such as mingw bash on Windows.
+  printf "%s" "${1}" | tr -d '[:space:]'
+}
+
+# parse distributionUrl and optional distributionSha256Sum, requires .mvn/wrapper/maven-wrapper.properties
+while IFS="=" read -r key value; do
+  case "${key-}" in
+  distributionUrl) distributionUrl=$(trim "${value-}") ;;
+  distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;
+  esac
+done <"${0%/*}/.mvn/wrapper/maven-wrapper.properties"
+[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in ${0%/*}/.mvn/wrapper/maven-wrapper.properties"
+
+case "${distributionUrl##*/}" in
+maven-mvnd-*bin.*)
+  MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/
+  case "${PROCESSOR_ARCHITECTURE-}${PROCESSOR_ARCHITEW6432-}:$(uname -a)" in
+  *AMD64:CYGWIN* | *AMD64:MINGW*) distributionPlatform=windows-amd64 ;;
+  :Darwin*x86_64) distributionPlatform=darwin-amd64 ;;
+  :Darwin*arm64) distributionPlatform=darwin-aarch64 ;;
+  :Linux*x86_64*) distributionPlatform=linux-amd64 ;;
+  *)
+    echo "Cannot detect native platform for mvnd on $(uname)-$(uname -m), use pure java version" >&2
+    distributionPlatform=linux-amd64
+    ;;
+  esac
+  distributionUrl="${distributionUrl%-bin.*}-$distributionPlatform.zip"
+  ;;
+maven-mvnd-*) MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/ ;;
+*) MVN_CMD="mvn${0##*/mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
+esac
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+[ -z "${MVNW_REPOURL-}" ] || distributionUrl="$MVNW_REPOURL$_MVNW_REPO_PATTERN${distributionUrl#*"$_MVNW_REPO_PATTERN"}"
+distributionUrlName="${distributionUrl##*/}"
+distributionUrlNameMain="${distributionUrlName%.*}"
+distributionUrlNameMain="${distributionUrlNameMain%-bin}"
+MAVEN_USER_HOME="${MAVEN_USER_HOME:-${HOME}/.m2}"
+MAVEN_HOME="${MAVEN_USER_HOME}/wrapper/dists/${distributionUrlNameMain-}/$(hash_string "$distributionUrl")"
+
+exec_maven() {
+  unset MVNW_VERBOSE MVNW_USERNAME MVNW_PASSWORD MVNW_REPOURL || :
+  exec "$MAVEN_HOME/bin/$MVN_CMD" "$@" || die "cannot exec $MAVEN_HOME/bin/$MVN_CMD"
+}
+
+if [ -d "$MAVEN_HOME" ]; then
+  verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  exec_maven "$@"
+fi
+
+case "${distributionUrl-}" in
+*?-bin.zip | *?maven-mvnd-?*-?*.zip) ;;
+*) die "distributionUrl is not valid, must match *-bin.zip or maven-mvnd-*.zip, but found '${distributionUrl-}'" ;;
+esac
+
+# prepare tmp dir
+if TMP_DOWNLOAD_DIR="$(mktemp -d)" && [ -d "$TMP_DOWNLOAD_DIR" ]; then
+  clean() { rm -rf -- "$TMP_DOWNLOAD_DIR"; }
+  trap clean HUP INT TERM EXIT
+else
+  die "cannot create temp dir"
+fi
+
+mkdir -p -- "${MAVEN_HOME%/*}"
+
+# Download and Install Apache Maven
+verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+verbose "Downloading from: $distributionUrl"
+verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+# select .zip or .tar.gz
+if ! command -v unzip >/dev/null; then
+  distributionUrl="${distributionUrl%.zip}.tar.gz"
+  distributionUrlName="${distributionUrl##*/}"
+fi
+
+# verbose opt
+__MVNW_QUIET_WGET=--quiet __MVNW_QUIET_CURL=--silent __MVNW_QUIET_UNZIP=-q __MVNW_QUIET_TAR=''
+[ "${MVNW_VERBOSE-}" != true ] || __MVNW_QUIET_WGET='' __MVNW_QUIET_CURL='' __MVNW_QUIET_UNZIP='' __MVNW_QUIET_TAR=v
+
+# normalize http auth
+case "${MVNW_PASSWORD:+has-password}" in
+'') MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+has-password) [ -n "${MVNW_USERNAME-}" ] || MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+esac
+
+if [ -z "${MVNW_USERNAME-}" ] && command -v wget >/dev/null; then
+  verbose "Found wget ... using wget"
+  wget ${__MVNW_QUIET_WGET:+"$__MVNW_QUIET_WGET"} "$distributionUrl" -O "$TMP_DOWNLOAD_DIR/$distributionUrlName" || die "wget: Failed to fetch $distributionUrl"
+elif [ -z "${MVNW_USERNAME-}" ] && command -v curl >/dev/null; then
+  verbose "Found curl ... using curl"
+  curl ${__MVNW_QUIET_CURL:+"$__MVNW_QUIET_CURL"} -f -L -o "$TMP_DOWNLOAD_DIR/$distributionUrlName" "$distributionUrl" || die "curl: Failed to fetch $distributionUrl"
+elif set_java_home; then
+  verbose "Falling back to use Java to download"
+  javaSource="$TMP_DOWNLOAD_DIR/Downloader.java"
+  targetZip="$TMP_DOWNLOAD_DIR/$distributionUrlName"
+  cat >"$javaSource" <<-END
+	public class Downloader extends java.net.Authenticator
+	{
+	  protected java.net.PasswordAuthentication getPasswordAuthentication()
+	  {
+	    return new java.net.PasswordAuthentication( System.getenv( "MVNW_USERNAME" ), System.getenv( "MVNW_PASSWORD" ).toCharArray() );
+	  }
+	  public static void main( String[] args ) throws Exception
+	  {
+	    setDefault( new Downloader() );
+	    java.nio.file.Files.copy( java.net.URI.create( args[0] ).toURL().openStream(), java.nio.file.Paths.get( args[1] ).toAbsolutePath().normalize() );
+	  }
+	}
+	END
+  # For Cygwin/MinGW, switch paths to Windows format before running javac and java
+  verbose " - Compiling Downloader.java ..."
+  "$(native_path "$JAVACCMD")" "$(native_path "$javaSource")" || die "Failed to compile Downloader.java"
+  verbose " - Running Downloader.java ..."
+  "$(native_path "$JAVACMD")" -cp "$(native_path "$TMP_DOWNLOAD_DIR")" Downloader "$distributionUrl" "$(native_path "$targetZip")"
+fi
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+if [ -n "${distributionSha256Sum-}" ]; then
+  distributionSha256Result=false
+  if [ "$MVN_CMD" = mvnd.sh ]; then
+    echo "Checksum validation is not supported for maven-mvnd." >&2
+    echo "Please disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  elif command -v sha256sum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  elif command -v shasum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | shasum -a 256 -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  else
+    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available." >&2
+    echo "Please install either command, or disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  fi
+  if [ $distributionSha256Result = false ]; then
+    echo "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised." >&2
+    echo "If you updated your Maven version, you need to update the specified distributionSha256Sum property." >&2
+    exit 1
+  fi
+fi
+
+# unzip and move
+if command -v unzip >/dev/null; then
+  unzip ${__MVNW_QUIET_UNZIP:+"$__MVNW_QUIET_UNZIP"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -d "$TMP_DOWNLOAD_DIR" || die "failed to unzip"
+else
+  tar xzf${__MVNW_QUIET_TAR:+"$__MVNW_QUIET_TAR"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -C "$TMP_DOWNLOAD_DIR" || die "failed to untar"
+fi
+printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/mvnw.url"
+mv -- "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
+
+clean || :
+exec_maven "$@"

--- a/spring_boot_multi_module/mvnw.cmd
+++ b/spring_boot_multi_module/mvnw.cmd
@@ -1,0 +1,149 @@
+<# : batch portion
+@REM ----------------------------------------------------------------------------
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM ----------------------------------------------------------------------------
+
+@REM ----------------------------------------------------------------------------
+@REM Apache Maven Wrapper startup batch script, version 3.3.2
+@REM
+@REM Optional ENV vars
+@REM   MVNW_REPOURL - repo url base for downloading maven distribution
+@REM   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+@REM   MVNW_VERBOSE - true: enable verbose log; others: silence the output
+@REM ----------------------------------------------------------------------------
+
+@IF "%__MVNW_ARG0_NAME__%"=="" (SET __MVNW_ARG0_NAME__=%~nx0)
+@SET __MVNW_CMD__=
+@SET __MVNW_ERROR__=
+@SET __MVNW_PSMODULEP_SAVE=%PSModulePath%
+@SET PSModulePath=
+@FOR /F "usebackq tokens=1* delims==" %%A IN (`powershell -noprofile "& {$scriptDir='%~dp0'; $script='%__MVNW_ARG0_NAME__%'; icm -ScriptBlock ([Scriptblock]::Create((Get-Content -Raw '%~f0'))) -NoNewScope}"`) DO @(
+  IF "%%A"=="MVN_CMD" (set __MVNW_CMD__=%%B) ELSE IF "%%B"=="" (echo %%A) ELSE (echo %%A=%%B)
+)
+@SET PSModulePath=%__MVNW_PSMODULEP_SAVE%
+@SET __MVNW_PSMODULEP_SAVE=
+@SET __MVNW_ARG0_NAME__=
+@SET MVNW_USERNAME=
+@SET MVNW_PASSWORD=
+@IF NOT "%__MVNW_CMD__%"=="" (%__MVNW_CMD__% %*)
+@echo Cannot start maven from wrapper >&2 && exit /b 1
+@GOTO :EOF
+: end batch / begin powershell #>
+
+$ErrorActionPreference = "Stop"
+if ($env:MVNW_VERBOSE -eq "true") {
+  $VerbosePreference = "Continue"
+}
+
+# calculate distributionUrl, requires .mvn/wrapper/maven-wrapper.properties
+$distributionUrl = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionUrl
+if (!$distributionUrl) {
+  Write-Error "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+}
+
+switch -wildcard -casesensitive ( $($distributionUrl -replace '^.*/','') ) {
+  "maven-mvnd-*" {
+    $USE_MVND = $true
+    $distributionUrl = $distributionUrl -replace '-bin\.[^.]*$',"-windows-amd64.zip"
+    $MVN_CMD = "mvnd.cmd"
+    break
+  }
+  default {
+    $USE_MVND = $false
+    $MVN_CMD = $script -replace '^mvnw','mvn'
+    break
+  }
+}
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+if ($env:MVNW_REPOURL) {
+  $MVNW_REPO_PATTERN = if ($USE_MVND) { "/org/apache/maven/" } else { "/maven/mvnd/" }
+  $distributionUrl = "$env:MVNW_REPOURL$MVNW_REPO_PATTERN$($distributionUrl -replace '^.*'+$MVNW_REPO_PATTERN,'')"
+}
+$distributionUrlName = $distributionUrl -replace '^.*/',''
+$distributionUrlNameMain = $distributionUrlName -replace '\.[^.]*$','' -replace '-bin$',''
+$MAVEN_HOME_PARENT = "$HOME/.m2/wrapper/dists/$distributionUrlNameMain"
+if ($env:MAVEN_USER_HOME) {
+  $MAVEN_HOME_PARENT = "$env:MAVEN_USER_HOME/wrapper/dists/$distributionUrlNameMain"
+}
+$MAVEN_HOME_NAME = ([System.Security.Cryptography.MD5]::Create().ComputeHash([byte[]][char[]]$distributionUrl) | ForEach-Object {$_.ToString("x2")}) -join ''
+$MAVEN_HOME = "$MAVEN_HOME_PARENT/$MAVEN_HOME_NAME"
+
+if (Test-Path -Path "$MAVEN_HOME" -PathType Container) {
+  Write-Verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"
+  exit $?
+}
+
+if (! $distributionUrlNameMain -or ($distributionUrlName -eq $distributionUrlNameMain)) {
+  Write-Error "distributionUrl is not valid, must end with *-bin.zip, but found $distributionUrl"
+}
+
+# prepare tmp dir
+$TMP_DOWNLOAD_DIR_HOLDER = New-TemporaryFile
+$TMP_DOWNLOAD_DIR = New-Item -Itemtype Directory -Path "$TMP_DOWNLOAD_DIR_HOLDER.dir"
+$TMP_DOWNLOAD_DIR_HOLDER.Delete() | Out-Null
+trap {
+  if ($TMP_DOWNLOAD_DIR.Exists) {
+    try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+    catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+  }
+}
+
+New-Item -Itemtype Directory -Path "$MAVEN_HOME_PARENT" -Force | Out-Null
+
+# Download and Install Apache Maven
+Write-Verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+Write-Verbose "Downloading from: $distributionUrl"
+Write-Verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+$webclient = New-Object System.Net.WebClient
+if ($env:MVNW_USERNAME -and $env:MVNW_PASSWORD) {
+  $webclient.Credentials = New-Object System.Net.NetworkCredential($env:MVNW_USERNAME, $env:MVNW_PASSWORD)
+}
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$webclient.DownloadFile($distributionUrl, "$TMP_DOWNLOAD_DIR/$distributionUrlName") | Out-Null
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+$distributionSha256Sum = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionSha256Sum
+if ($distributionSha256Sum) {
+  if ($USE_MVND) {
+    Write-Error "Checksum validation is not supported for maven-mvnd. `nPlease disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties."
+  }
+  Import-Module $PSHOME\Modules\Microsoft.PowerShell.Utility -Function Get-FileHash
+  if ((Get-FileHash "$TMP_DOWNLOAD_DIR/$distributionUrlName" -Algorithm SHA256).Hash.ToLower() -ne $distributionSha256Sum) {
+    Write-Error "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised. If you updated your Maven version, you need to update the specified distributionSha256Sum property."
+  }
+}
+
+# unzip and move
+Expand-Archive "$TMP_DOWNLOAD_DIR/$distributionUrlName" -DestinationPath "$TMP_DOWNLOAD_DIR" | Out-Null
+Rename-Item -Path "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" -NewName $MAVEN_HOME_NAME | Out-Null
+try {
+  Move-Item -Path "$TMP_DOWNLOAD_DIR/$MAVEN_HOME_NAME" -Destination $MAVEN_HOME_PARENT | Out-Null
+} catch {
+  if (! (Test-Path -Path "$MAVEN_HOME" -PathType Container)) {
+    Write-Error "fail to move MAVEN_HOME"
+  }
+} finally {
+  try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+  catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+}
+
+Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"

--- a/spring_boot_multi_module/pom.xml
+++ b/spring_boot_multi_module/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>3.4.0</version>
+		<relativePath/> <!-- lookup parent from repository -->
+	</parent>
+	<groupId>com.davidr</groupId>
+	<artifactId>spring_boot_multi_module</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<packaging>pom</packaging>
+	<name>spring_boot_multi_module</name>
+	<description>Multi-module Spring Boot demo project</description>
+
+	<properties>
+		<java.version>21</java.version>
+	</properties>
+
+	<modules>
+		<module>common</module>
+		<module>web</module>
+	</modules>
+
+</project>

--- a/spring_boot_multi_module/web/pom.xml
+++ b/spring_boot_multi_module/web/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>com.davidr</groupId>
+		<artifactId>spring_boot_multi_module</artifactId>
+		<version>0.0.1-SNAPSHOT</version>
+	</parent>
+	<artifactId>web</artifactId>
+	<name>web</name>
+	<description>Spring Boot web application</description>
+
+	<dependencies>
+		<dependency>
+			<groupId>com.davidr</groupId>
+			<artifactId>common</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/spring_boot_multi_module/web/src/main/java/com/davidr/web/Application.java
+++ b/spring_boot_multi_module/web/src/main/java/com/davidr/web/Application.java
@@ -1,0 +1,12 @@
+package com.davidr.web;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication(scanBasePackages = "com.davidr")
+public class Application {
+
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+}

--- a/spring_boot_multi_module/web/src/main/java/com/davidr/web/HelloController.java
+++ b/spring_boot_multi_module/web/src/main/java/com/davidr/web/HelloController.java
@@ -1,0 +1,27 @@
+package com.davidr.web;
+
+import com.davidr.common.model.Greeting;
+import com.davidr.common.service.GreetingService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HelloController {
+
+    private final GreetingService greetingService;
+
+    public HelloController(GreetingService greetingService) {
+        this.greetingService = greetingService;
+    }
+
+    @GetMapping
+    public String hello() {
+        return "Hello, World!";
+    }
+
+    @GetMapping("/greet")
+    public Greeting greet(@RequestParam(defaultValue = "World") String name) {
+        return greetingService.getGreeting(name);
+    }
+}

--- a/spring_boot_multi_module/web/src/main/resources/application.properties
+++ b/spring_boot_multi_module/web/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+spring.application.name = spring_boot_multi_module
+server.port = ${server.port:8080}

--- a/spring_boot_multi_module/web/src/test/java/com/davidr/web/ApplicationTests.java
+++ b/spring_boot_multi_module/web/src/test/java/com/davidr/web/ApplicationTests.java
@@ -1,0 +1,12 @@
+package com.davidr.web;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class ApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+}

--- a/vuejs/package-lock.json
+++ b/vuejs/package-lock.json
@@ -80,6 +80,7 @@
       "integrity": "sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.0",
@@ -1698,6 +1699,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -2634,6 +2636,7 @@
       "integrity": "sha512-61fXYl/qNVinKmGSTHAZ6Yy8I3YIJC/r2m9feHo6SwVAVcLT5MPwOUFe7EuURA/4m0NR8lXG4BBXuo/IZEsjMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.6"
       },
@@ -2821,6 +2824,7 @@
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2896,6 +2900,7 @@
       "integrity": "sha512-Cmuo5P0ENTN6HxLSo6IHsjCLn/81Vgrp81oaiFFMRa8gGDj5xEjIcEpf2ZymZtZR8oU0P2JX5WuUp/rlXcHkAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.24.0",
         "postcss": "^8.4.49",
@@ -3062,6 +3067,7 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.13.tgz",
       "integrity": "sha512-wmeiSMxkZCSc+PM2w2VRsOYAZC8GdipNFRTsLSfodVqI9mbejKeXEGr8SckuLnrQPGe3oJN5c3K0vpoU9q/wCQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.13",
         "@vue/compiler-sfc": "3.5.13",


### PR DESCRIPTION
This pull request introduces a new example for a multi-module Spring Boot project with Docker support, including optimized Dockerfiles and supporting files. It also makes minor documentation and dependency metadata updates to other parts of the repository. The main focus is on providing a reusable, production-ready template for building and containerizing Spring Boot applications with shared modules.

**Spring Boot Multi-Module Example:**

- Added a complete multi-module Spring Boot project under `spring_boot_multi_module`, featuring a shared `common` library and a `web` application module, with sample code for a greeting service and controller. [[1]](diffhunk://#diff-ac4d99fe6221d5fc276594addff854da36586e625e3a72854547d2de8efb781aR1-R104) [[2]](diffhunk://#diff-6e8d0a83a6b94d45ca732be0304749bc3b367766e456a4bf76d849803f87681aR1-R21) [[3]](diffhunk://#diff-2c9ff8175c6a9a1cfd8c7e31516e1bcdfa4d026cf17dd5032342b15e272cc83eR1-R31) [[4]](diffhunk://#diff-63e1d27f28f27b842cf62724b4cc5c626d5ffb4e5ee0835b8ed68b5fb7d279f7R1-R17)
- Included two Dockerfiles (`Dockerfile`, `Dockerfile_EclipseTemurin`) that demonstrate best practices for building minimal images, such as using `jdeps`/`jlink` for custom JRE creation and multi-stage builds. [[1]](diffhunk://#diff-85fd9929f16f21fb0b0fe2f20a38750a5caeb5fefca9384c578b80877d96418eR1-R51) [[2]](diffhunk://#diff-57d67bcfeffe5c1e298cec52e0210986231b2b5155a382c4bd02f9e86a6a6095R1-R25)
- Added supporting project files: `.dockerignore`, `.gitignore`, `.gitattributes`, and Maven wrapper properties for reproducible builds and cleaner Docker contexts. [[1]](diffhunk://#diff-e78a379db77c6abf237506f4d6ff700e3567deb4a33f4b692d4c45ec16905d8cR1-R14) [[2]](diffhunk://#diff-74887d05d17896f75de6d8d0bb853b485e5371717ffb6667c8f1b38ce9ceca98R1-R33) [[3]](diffhunk://#diff-7e4dfad0dad93740994e913af9704b8cce42e3fc17aff118733ea86e1af4229dR1-R2) [[4]](diffhunk://#diff-a54c7d877339e2cb401c1344c1095cb2fdc334cb121f4ca8efb37a152df77c30R1-R19)
- Provided a comprehensive `README.md` with setup, build, and usage instructions tailored to multi-module Spring Boot projects in Docker.

**Repository Documentation and Metadata Updates:**

- Updated the root `README.md` to list the new Spring Boot multi-module example and clarified the React Vite entry.
- Minor updates to `package-lock.json` files in `nextjs` and `react_vite` to mark some dependencies as peer dependencies, improving dependency management. [[1]](diffhunk://#diff-017d63237b2c4a55f9f7d67fe1585dedf03576e13702484ccea7fed3b4f2d382R1600) [[2]](diffhunk://#diff-017d63237b2c4a55f9f7d67fe1585dedf03576e13702484ccea7fed3b4f2d382R1770) [[3]](diffhunk://#diff-017d63237b2c4a55f9f7d67fe1585dedf03576e13702484ccea7fed3b4f2d382R1780) [[4]](diffhunk://#diff-9a5f676aca393590ab866e7e52a95eddf434376d9a9b86f3165c351d60e062f6R74) [[5]](diffhunk://#diff-9a5f676aca393590ab866e7e52a95eddf434376d9a9b86f3165c351d60e062f6R1369) [[6]](diffhunk://#diff-9a5f676aca393590ab866e7e52a95eddf434376d9a9b86f3165c351d60e062f6R1421) [[7]](diffhunk://#diff-9a5f676aca393590ab866e7e52a95eddf434376d9a9b86f3165c351d60e062f6R1631) [[8]](diffhunk://#diff-9a5f676aca393590ab866e7e52a95eddf434376d9a9b86f3165c351d60e062f6R1740) [[9]](diffhunk://#diff-9a5f676aca393590ab866e7e52a95eddf434376d9a9b86f3165c351d60e062f6R1959) [[10]](diffhunk://#diff-9a5f676aca393590ab866e7e52a95eddf434376d9a9b86f3165c351d60e062f6R2791) [[11]](diffhunk://#diff-9a5f676aca393590ab866e7e52a95eddf434376d9a9b86f3165c351d60e062f6R3033) [[12]](diffhunk://#diff-9a5f676aca393590ab866e7e52a95eddf434376d9a9b86f3165c351d60e062f6R3112)